### PR TITLE
feat: add toResult

### DIFF
--- a/shared/src/commonMain/kotlin/com/example/tasky/dataSource/AgendaDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/example/tasky/dataSource/AgendaDataSource.kt
@@ -3,13 +3,11 @@ package com.example.tasky.dataSource
 import com.example.tasky.manager.HttpManager
 import com.example.tasky.model.BaseError
 import com.example.tasky.model.DataError
-import com.example.tasky.model.ErrorResponse
 import com.example.tasky.model.ResultWrapper
 import com.example.tasky.model.agenda.Agenda
 import com.example.tasky.model.agenda.GetAgendaResponse
-import com.example.tasky.util.isSuccess
+import com.example.tasky.util.toResult
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.plugins.resources.get
 import io.ktor.client.request.parameter
 import kotlin.coroutines.cancellation.CancellationException
@@ -17,25 +15,18 @@ import kotlin.coroutines.cancellation.CancellationException
 class AgendaDataSource(
     private val httpClient: HttpClient = HttpManager.httpClient,
 ) {
-    suspend fun getAgenda(timeStamp: Long): ResultWrapper<GetAgendaResponse, BaseError> {
-        return try {
+    suspend fun getAgenda(timeStamp: Long): ResultWrapper<GetAgendaResponse, BaseError> =
+        try {
             val response =
                 httpClient.get(Agenda()) {
                     parameter("time", timeStamp)
                 }
 
-            if (!response.isSuccess()) {
-                val errorResponse = response.body<ErrorResponse>()
-                println("get agenda fail: ${errorResponse.message}")
-                return ResultWrapper.Error(DataError.Remote.UNKNOWN)
-            }
-
-            ResultWrapper.Success(response.body<GetAgendaResponse>())
+            response.toResult<GetAgendaResponse>()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
 
             Throwable(e)
             ResultWrapper.Error(DataError.Remote.UNKNOWN)
         }
-    }
 }

--- a/shared/src/commonMain/kotlin/com/example/tasky/dataSource/LoginDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/example/tasky/dataSource/LoginDataSource.kt
@@ -3,16 +3,14 @@ package com.example.tasky.dataSource
 import com.example.tasky.manager.HttpManager
 import com.example.tasky.model.BaseError
 import com.example.tasky.model.DataError
-import com.example.tasky.model.ErrorResponse
 import com.example.tasky.model.ResultWrapper
 import com.example.tasky.model.login.Login
 import com.example.tasky.model.login.LoginBody
 import com.example.tasky.model.login.LoginResponse
 import com.example.tasky.model.login.Register
 import com.example.tasky.model.login.RegisterBody
-import com.example.tasky.util.isSuccess
+import com.example.tasky.util.toResult
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.plugins.resources.post
 import io.ktor.client.request.setBody
 import kotlin.coroutines.cancellation.CancellationException
@@ -20,47 +18,33 @@ import kotlin.coroutines.cancellation.CancellationException
 class LoginDataSource(
     private val httpClient: HttpClient = HttpManager.httpClient,
 ) {
-    suspend fun login(loginBody: LoginBody): ResultWrapper<LoginResponse, BaseError> {
-        return try {
+    suspend fun login(loginBody: LoginBody): ResultWrapper<LoginResponse, BaseError> =
+        try {
             val response =
                 httpClient.post(Login()) {
                     setBody(loginBody)
                 }
 
-            if (!response.isSuccess()) {
-                val errorResponse = response.body<ErrorResponse>()
-                println("login fail: ${errorResponse.message}")
-                return ResultWrapper.Error(DataError.Remote.UNKNOWN)
-            }
-
-            ResultWrapper.Success(response.body<LoginResponse>())
+            response.toResult<LoginResponse>()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
 
             Throwable(e)
             ResultWrapper.Error(DataError.Remote.UNKNOWN)
         }
-    }
 
-    suspend fun register(registerBody: RegisterBody): ResultWrapper<Unit, BaseError> {
-        return try {
+    suspend fun register(registerBody: RegisterBody): ResultWrapper<Unit, BaseError> =
+        try {
             val response =
                 httpClient.post(Register()) {
                     setBody(registerBody)
                 }
 
-            if (!response.isSuccess()) {
-                val errorResponse = response.body<ErrorResponse>()
-                println("register fail: ${errorResponse.message}")
-                return ResultWrapper.Error(DataError.Remote.UNKNOWN)
-            }
-
-            ResultWrapper.Success(Unit)
+            response.toResult<Unit>()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
 
             Throwable(e)
             ResultWrapper.Error(DataError.Remote.UNKNOWN)
         }
-    }
 }

--- a/shared/src/commonMain/kotlin/com/example/tasky/model/BaseError.kt
+++ b/shared/src/commonMain/kotlin/com/example/tasky/model/BaseError.kt
@@ -4,6 +4,15 @@ interface BaseError
 
 sealed interface DataError : BaseError {
     enum class Remote : DataError {
+        BAD_REQUEST,
+        UNAUTHORIZED,
+        FORBIDDEN,
+        NOT_FOUND,
+        REQUEST_TIMEOUT,
+        CONFLICT,
+        PAYLOAD_TOO_LARGE,
+        TOO_MANY_REQUESTS,
+        SERVER_ERROR,
         UNKNOWN,
     }
 }

--- a/shared/src/commonMain/kotlin/com/example/tasky/util/HttpResponseExtension.kt
+++ b/shared/src/commonMain/kotlin/com/example/tasky/util/HttpResponseExtension.kt
@@ -1,5 +1,23 @@
 package com.example.tasky.util
 
+import com.example.tasky.model.DataError
+import com.example.tasky.model.ResultWrapper
+import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 
 fun HttpResponse.isSuccess(): Boolean = status.value in 200..299
+
+suspend inline fun <reified T> HttpResponse.toResult(): ResultWrapper<T, DataError.Remote> =
+    when (status.value) {
+        in 200..299 -> ResultWrapper.Success(body<T>())
+        400 -> ResultWrapper.Error(DataError.Remote.BAD_REQUEST)
+        401 -> ResultWrapper.Error(DataError.Remote.UNAUTHORIZED)
+        403 -> ResultWrapper.Error(DataError.Remote.FORBIDDEN)
+        404 -> ResultWrapper.Error(DataError.Remote.NOT_FOUND)
+        408 -> ResultWrapper.Error(DataError.Remote.REQUEST_TIMEOUT)
+        409 -> ResultWrapper.Error(DataError.Remote.CONFLICT)
+        413 -> ResultWrapper.Error(DataError.Remote.PAYLOAD_TOO_LARGE)
+        429 -> ResultWrapper.Error(DataError.Remote.TOO_MANY_REQUESTS)
+        in 500..599 -> ResultWrapper.Error(DataError.Remote.SERVER_ERROR)
+        else -> ResultWrapper.Error(DataError.Remote.UNKNOWN)
+    }


### PR DESCRIPTION
add more Errors to DataError.Remote
add extension fun toResult to HttpResponse
use toResult for mapping response to ResultWrapper in fun calling api in DataSources